### PR TITLE
Make the message argument optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,11 +22,11 @@ declare module makeError {
     name: string;
     stack: string;
 
-    constructor(message: string);
+    constructor(message?: string);
   }
 
   export interface Constructor <T> {
-    new (message: string): T
+    new (message?: string): T
     super_: any
     prototype: T
   }


### PR DESCRIPTION
It's valid to construct a new Error without an argument; it's treated as an empty string.