### PR TITLE
Add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "make-error",
   "version": "1.2.3",
+  "main": "index.js",
   "license": "ISC",
   "description": "Make your own error types!",
   "keywords": [


### PR DESCRIPTION
While Node by default use `index.js` when `package.json/main` is not specified, missing the main field cause problem for the library to be loaded by `systemjs`.

https://github.com/systemjs/systemjs/issues/1603

It would be nice to just fill it in and make it easier for users in `systemjs`. 🌷 

Best