### PR TITLE
BaseError extends, rather than implements Error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare namespace makeError {
   /**
    * Use with ES2015+ inheritance.
    */
-  export class BaseError implements Error {
+  export class BaseError extends Error {
     message: string;
     name: string;
     stack: string;


### PR DESCRIPTION
This better represents the underlying JavaScript:
```
BaseError.prototype = Object.create(Error.prototype, {
  // See: https://github.com/JsCommunity/make-error/issues/4
  constructor: {
    configurable: true,
    value: BaseError,
    writable: true,
  },
});
```
https://github.com/JsCommunity/make-error/blob/master/index.js#L65